### PR TITLE
Uniqueify the list-all versions list

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval curl -s http://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions)
+versions=$(eval curl -s http://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions | uniq)
 echo $versions


### PR DESCRIPTION
Removes duplicate values from the versions list rendered by `list-all`.

Before:

```
% asdf list-all spark | tail

3.0.1
3.0.1
3.0.2
3.0.2
3.0.3
3.0.3
3.1.1
3.1.1
3.1.2
3.1.2
```

After:

```
% asdf list-all spark | tail

2.4.5
2.4.6
2.4.7
2.4.8
3.0.0
3.0.1
3.0.2
3.0.3
3.1.1
3.1.2
```