### PR TITLE
follow redirect to https in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval curl -s http://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions)
+versions=$(eval curl -s --location http://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions)
 echo $versions


### PR DESCRIPTION
fix `No compatible versions available (spark )` because
http://spark.apache.org/releases/ redirects to https://spark.apache.org/releases/