### PR TITLE
Fix broken Spark download url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -39,7 +39,7 @@ get_download_file_path() {
   local version=$1
   local tmp_download_dir=$2
 
-  local pkg_name="spark-${version}-bin-hadoop2.7.tgz"
+  local pkg_name="spark-${version}-bin-hadoop$(get_hadoop_version $version).tgz"
 
   echo "$tmp_download_dir/$pkg_name"
 }
@@ -48,7 +48,7 @@ get_download_file_path() {
 get_download_url() {
   local version=$1
   local default="https://www.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop$(get_hadoop_version $version).tgz"
-  local fallback="https://archive.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop2.7.tgz"
+  local fallback="https://archive.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop$(get_hadoop_version $version).tgz"
 
   if wget -q --spider "$default"; then
     echo $default

--- a/bin/install
+++ b/bin/install
@@ -47,13 +47,23 @@ get_download_file_path() {
 
 get_download_url() {
   local version=$1
-  local default="https://www.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop2.7.tgz"
+  local default="https://www.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop$(get_hadoop_version $version).tgz"
   local fallback="https://archive.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop2.7.tgz"
 
   if wget -q --spider "$default"; then
     echo $default
   else
     echo $fallback
+  fi;
+}
+
+get_hadoop_version() {
+  local version=$1
+  
+  if (( ${version:0:1} >= 3 )); then
+    echo "2"
+  else
+      echo "2.7"
   fi;
 }
 

--- a/bin/install
+++ b/bin/install
@@ -63,7 +63,7 @@ get_hadoop_version() {
   if (( ${version:0:1} >= 3 )); then
     echo "2"
   else
-      echo "2.7"
+    echo "2.7"
   fi;
 }
 


### PR DESCRIPTION
### Description
Since Spark 3.x, the [Spark dist](https://archive.apache.org/dist/spark/) download URL has changed to `...hadoop2.tgz` from `...hadoop2.7.tgz`, causing installs of Spark versions >= 3.x to fail.