### PR TITLE
Fix for apache versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -39,7 +39,7 @@ get_download_file_path() {
   local version=$1
   local tmp_download_dir=$2
 
-  local pkg_name="spark-${version}-bin-hadoop2.7.tgz"
+  local pkg_name="spark-${version}.tgz"
 
   echo "$tmp_download_dir/$pkg_name"
 }

--- a/bin/install
+++ b/bin/install
@@ -47,14 +47,8 @@ get_download_file_path() {
 
 get_download_url() {
   local version=$1
-  local default="https://www.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop2.7.tgz"
-  local fallback="https://archive.apache.org/dist/spark/spark-${version}/spark-${version}-bin-hadoop2.7.tgz"
-
-  if wget -q --spider "$default"; then
-    echo $default
-  else
-    echo $fallback
-  fi;
+  local sparkBaseVersion=$(echo $version | cut -d'-' -f1)
+  echo "https://archive.apache.org/dist/spark/spark-${sparkBaseVersion}/spark-${version}.tgz"
 }
 
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval curl -s 'https://archive.apache.org/dist/spark/' | grep "spark-" | cut -d'>' -f3 | cut -d '/' -f1 | sed 's/spark-//g')
+versions=$(eval curl -s 'https://archive.apache.org/dist/spark/' | grep "spark-" | cut -d'>' -f3 | cut -d '/' -f1 | xargs -I{} curl -s "https://archive.apache.org/dist/spark/{}/" | grep '.tgz</a' | cut -d '>' -f3 | cut -d'<' -f1 | sed 's/.tgz//g' | sed 's/spark-//g')
 echo $versions

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval curl -s http://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions)
+versions=$(eval curl -s https://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions | uniq)
 echo $versions

--- a/bin/list-all
+++ b/bin/list-all
@@ -7,5 +7,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval curl -s https://spark.apache.org/releases/ | grep -oE "spark-release-[0-9]*-[0-9]*-[0-9]*.html" | sed 's/spark-release-\(.*\).html/\1/g' | sed 's/-/./g' | sort_versions | uniq)
+versions=$(eval curl -s 'https://archive.apache.org/dist/spark/' | grep "spark-" | cut -d'>' -f3 | cut -d '/' -f1 | sed 's/spark-//g')
 echo $versions


### PR DESCRIPTION
Fix list and downloads by allowing using any available versions, all variants like `spark-3.3.1-bin.hadoop3` or `3.3.3-bin-hadoop3-scala2.13` or `3.0.3-bin-hadoop2.7` and many more

closes #2 